### PR TITLE
Enable CORS option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # Core
 NODE_ENV=
 DEBUG_MODE=
+CORS_ORIGINS=
 # Database
 MONGO_DB_URI=
 # Grafana Loki

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,35 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { WinstonProvider } from '@common/winston/winston.provider';
+import { ConfigService } from '@nestjs/config';
+import { map } from 'lodash';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  const configService = app.get<ConfigService>(ConfigService);
+  const configuredOrigins = configService
+    .get<string>('CORS_ORIGINS')
+    .split(/\s*,\s*/);
+
+  const origins = map(
+    configuredOrigins?.length > 0 ? configuredOrigins : undefined,
+    (origin) => {
+      if (origin.startsWith('/') && origin.endsWith('/')) {
+        return new RegExp(origin);
+      } else {
+        return origin;
+      }
+    },
+  );
+
+  app.enableCors({
+    origin: origins.length > 0 ? origins : false,
+    methods: ['GET', 'HEAD'],
+    preflightContinue: false,
+    optionsSuccessStatus: 204,
+  });
   app.useLogger(app.get(WinstonProvider));
+
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
### Description
CORS will enable when you set the `CORS_ORIGINS` environment variable. otherwise, CORS is disabled by default.

NOTE:
you can set the origin as `string` or `regex`. also, you can set **multi origins** like the following example:
```
CORS_ORIGINS=http://localhost:3000,/\.example2\.com$/
```
the above example will parse as the following array:
```ts
[ 'http://localhost:3000', /\/\.example2\.com$\// ]
```
### Done Tasks

- closed #19 